### PR TITLE
v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note that no default options are provided for Stefon/Garden, as those will vary 
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/components.assets "1.0.1"]
+[com.nedap.staffing-solutions/components.assets "2.0.0"]
 ````
 
 #### NOTE

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/components.assets "1.0.1"
+(defproject com.nedap.staffing-solutions/components.assets "2.0.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/stefon "0.5.1"
                   :exclusions [clj-time commons-codec com.fasterxml.jackson.core/jackson-core]]


### PR DESCRIPTION
Delivers: https://github.com/nedap/components.assets/pull/6

This is a breaking change, the `:manifest-file` now has to be configured like https://github.com/nedap/pep-key/pull/858 does:

```clj
   :manifest-file (if (running-in-jar?)
                    (-> "manifest.json" io/resource str)
                    (-> "manifest.json" ensure-path))
```

## Release checklist (author)

* [x] All PRs / relevant commits since the previous release are listed in this PR's description 
* [x] The new proposed version follows semver 
* [x] The build passes
* [x] New features are (briefly) reflected in the README

## Release checklist (reviewer)

* [ ] All PRs / relevant commits since the previous release are listed in this PR's description 
* [ ] The new proposed version follows semver 
* [ ] New features are (briefly) reflected in the README
