### PR TITLE
Allow for multiple garden options in a single component

### DIFF
--- a/src/nedap/components/assets/component.clj
+++ b/src/nedap/components/assets/component.clj
@@ -23,7 +23,7 @@ This option is only apt for development."
   "A Garden build as per its official doc. Only :compiler and :stylesheet will be used, you can omit the rest."
   (spec/keys :req-un [::compiler ::stylesheet]))
 
-(speced/def-with-doc ::garden-options-collection
+(speced/def-with-doc ::garden-options-coll
   "A collection of garden options."
   (spec/coll-of ::garden-options :min-count 1))
 
@@ -48,7 +48,7 @@ You can use `print-all-webjar-assets` in order to figure out the resource names.
 (spec/def ::webjar-options (spec/keys :req [::webjars.mappings]
                                       :opt [::webjars.asset-directory]))
 
-(spec/def ::component (spec/keys :req [::garden-options-collection ::stefon-options ::webjar-options]
+(spec/def ::component (spec/keys :req [::garden-options-coll ::stefon-options ::webjar-options]
                                  :opt [::run-in-background?]))
 
 (defn print-all-webjar-assets
@@ -70,11 +70,11 @@ You can use `print-all-webjar-assets` in order to figure out the resource names.
       (copy-file-from-resource webjar-name
                                (str asset-directory asset-name)))))
 
-(speced/defn compile-assets! [{::keys [garden-options-collection
+(speced/defn compile-assets! [{::keys [garden-options-coll
                                        ^::stefon-options stefon-options
                                        webjar-options]}]
   (copy-webjars! webjar-options)
-  (doseq [garden-options garden-options-collection]
+  (doseq [garden-options garden-options-coll]
     (compile-css! garden-options))
   (stefon/precompile stefon-options))
 

--- a/src/nedap/components/assets/component.clj
+++ b/src/nedap/components/assets/component.clj
@@ -23,6 +23,10 @@ This option is only apt for development."
   "A Garden build as per its official doc. Only :compiler and :stylesheet will be used, you can omit the rest."
   (spec/keys :req-un [::compiler ::stylesheet]))
 
+(speced/def-with-doc ::garden-options-collection
+  "A collection of garden options."
+  (spec/coll-of ::garden-options :min-count 1))
+
 (speced/def-with-doc ::stefon-options
   "A Stefon map, as per its official doc."
   map?)
@@ -44,7 +48,7 @@ You can use `print-all-webjar-assets` in order to figure out the resource names.
 (spec/def ::webjar-options (spec/keys :req [::webjars.mappings]
                                       :opt [::webjars.asset-directory]))
 
-(spec/def ::component (spec/keys :req [::garden-options ::stefon-options ::webjar-options]
+(spec/def ::component (spec/keys :req [::garden-options-collection ::stefon-options ::webjar-options]
                                  :opt [::run-in-background?]))
 
 (defn print-all-webjar-assets
@@ -66,11 +70,12 @@ You can use `print-all-webjar-assets` in order to figure out the resource names.
       (copy-file-from-resource webjar-name
                                (str asset-directory asset-name)))))
 
-(speced/defn compile-assets! [{::keys [garden-options
+(speced/defn compile-assets! [{::keys [garden-options-collection
                                        ^::stefon-options stefon-options
                                        webjar-options]}]
   (copy-webjars! webjar-options)
-  (compile-css! garden-options)
+  (doseq [garden-options garden-options-collection]
+    (compile-css! garden-options))
   (stefon/precompile stefon-options))
 
 (defn start [{::keys [run-in-background?]
@@ -84,8 +89,7 @@ You can use `print-all-webjar-assets` in order to figure out the resource names.
       (impl))
     this))
 
-(speced/defn new [{::keys [garden-options stefon-options webjar-options]
-                   :as    ^::component this}]
+(speced/defn new [^::component this]
   (implement this
     component/start start
     component/stop  identity))


### PR DESCRIPTION
## Brief

Replace `:garden-options` with `:garden-options-coll`, which allows consumers to create single assets component while creating multiple stylesheets with garden.

This will be used by key, which now produces `legacy-styles.css` and a new `styles.css` for the redesigned UI.

Naming is a bit meh, but `:options` refers to a singular map, hence the `-coll` suffix. Suggestions on naming are welcome.

## QA plan

<!-- Please state a reproducible plan to prove this PR works. Attach screenshots, gifs, etc. if needed. Occasionally, sufficient test coverage removes the need for QAing. -->

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [ ] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [ ] The build passes
* [ ] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
