### PR TITLE
Remove JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ jobs:
           name: Perform pre-release sanity check
           command: lein with-profile -dev,+ci,+ncrw run -m nedap.ci.release-workflow.api sanity-check
       - run:
-          name: release to JFrog
-          command: lein deploy
-      - run:
           name: release to Clojars
           command: lein deploy clojars          
 
@@ -93,12 +90,10 @@ workflows:
           name: "Ensure artifact isolation, inform of boxed math"
           jdk_version: openjdk8
           lein_test_command: lein with-profile -dev,+check check
-          context: JFrog
           <<: *test_code_filters
       - cloverage:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
-          context: JFrog
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, plain"
@@ -107,7 +102,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
           <<: *test_code_filters
       - test_code:
           name: "JDK 8, with production-like compiler flags"
@@ -116,7 +110,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
           <<: *test_code_filters
       - test_code:
           name: "JDK 11, plain"
@@ -125,7 +118,6 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
           <<: *test_code_filters
       - test_code:
           name: "JDK 11, with production-like compiler flags"
@@ -134,10 +126,12 @@ workflows:
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage
-          context: JFrog
           <<: *test_code_filters
       - deploy:
-          context: JFrog
+          context:
+            - Clojars
+            - Github
+            - GPG
           requires:
             - "Ensure artifact isolation, inform of boxed math"
             - cloverage

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note that no default options are provided for Stefon/Garden, as those will vary 
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/components.assets "3.0.0"]
+[com.nedap.staffing-solutions/components.assets "3.0.1-alpha1"]
 ````
 
 #### NOTE

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/components.assets "3.0.0"
+(defproject com.nedap.staffing-solutions/components.assets "3.0.1-alpha1"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/stefon "0.5.2"
                   :exclusions [clj-time commons-codec com.fasterxml.jackson.core/jackson-core]]

--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/stefon "0.5.2"
                   :exclusions [clj-time commons-codec com.fasterxml.jackson.core/jackson-core]]
-                 [com.nedap.staffing-solutions/utils.io "1.1.0"
+                 [com.nedap.staffing-solutions/utils.io "2.0.0"
                   :exclusions [com.nedap.staffing-solutions/speced.def
                                org.apache.commons/commons-compress]]
                  [com.nedap.staffing-solutions/speced.def "2.0.0"]
-                 [com.nedap.staffing-solutions/utils.modular "2.2.0-alpha3"]
+                 [com.nedap.staffing-solutions/utils.modular "2.2.0"]
                  [com.stuartsierra/component "0.4.0"]
                  [garden "1.3.5"]
                  [org.apache.commons/commons-compress "1.18"]
@@ -16,6 +16,8 @@
                   :exclusions [org.apache.commons/commons-compress]]
                  ;; Stefon needs it. We ensure a recent version is used, as the default (older) has an issue:
                  [ring/ring-core "1.5.0"]]
+
+  :managed-dependencies [[org.clojure/tools.cli "1.0.194"]]
 
   :description "Clojure Component bundling Stefon, Garden and WebJars functionality."
 
@@ -28,13 +30,9 @@
 
   :signing {:gpg-key "releases-staffingsolutions@nedap.com"}
 
-  :repositories {"releases" {:url      "https://nedap.jfrog.io/nedap/staffing-solutions/"
-                             :username :env/artifactory_user
-                             :password :env/artifactory_pass}}
-
-  :repository-auth {#"https://nedap.jfrog\.io/nedap/staffing-solutions/"
-                    {:username :env/artifactory_user
-                     :password :env/artifactory_pass}}
+  :repositories        {"github" {:url "https://maven.pkg.github.com/nedap/*"
+                                  :username "github"
+                                  :password :env/github_token}}
 
   :deploy-repositories {"clojars" {:url      "https://clojars.org/repo"
                                    :username :env/clojars_user
@@ -98,7 +96,7 @@
                           :test-paths     ^:replace []
                           :resource-paths ^:replace []
                           :plugins        ^:replace []
-                          :dependencies   ^:replace [[com.nedap.staffing-solutions/ci.release-workflow "1.13.1"]]}
+                          :dependencies   ^:replace [[com.nedap.staffing-solutions/ci.release-workflow "1.14.1"]]}
 
              :ci       {:pedantic?    :abort
                         :jvm-opts     ["-Dclojure.main.report=stderr"]}})


### PR DESCRIPTION
## Brief

It's not in use as we publish to Clojars too, so let's remove the explicit but not-really used dependency on JFrog.

## QA plan

- [x] CI

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
