### PR TITLE
Fetch stable Stefon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Note that no default options are provided for Stefon/Garden, as those will vary 
 
 ```clojure
 [com.nedap.staffing-solutions/components.assets "3.0.1"]
-````
+```
+
+Since `v4.0.0` the `nedap` fork for `circleci/stefon` was replaced by its upstream on Clojars. These versions have minor differences. If needed, you can use https://github.com/reifyhealth/lein-git-down to fetch `HEAD` for `circleci/stefon` from GitHub directly.
 
 #### NOTE
 
-You may have to apply ` exclusions [com.google.guava/guava com.google.protobuf/protobuf-java com.google.javascript/closure-compiler]` in order to prevent a ClojureScript compilation from popping up (which doesn't make sense in a JVM project) and failing the build.
+You may have to apply `exclusions [com.google.guava/guava com.google.protobuf/protobuf-java com.google.javascript/closure-compiler]` in order to prevent a ClojureScript compilation from popping up (which doesn't make sense in a JVM project) and failing the build.
 
 ## ns organisation
 

--- a/project.clj
+++ b/project.clj
@@ -1,23 +1,23 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
 (defproject com.nedap.staffing-solutions/components.assets "3.0.1"
   ;; Please keep the dependencies sorted a-z.
-  :dependencies [[com.nedap.staffing-solutions/stefon "0.5.2"
-                  :exclusions [clj-time commons-codec com.fasterxml.jackson.core/jackson-core]]
-                 [com.nedap.staffing-solutions/utils.io "2.0.0"
-                  :exclusions [com.nedap.staffing-solutions/speced.def
-                               org.apache.commons/commons-compress]]
+  :dependencies [[circleci/stefon "0.5.0-20130815.014939-2"]
+                 [com.nedap.staffing-solutions/utils.io "2.0.0"]
                  [com.nedap.staffing-solutions/speced.def "2.0.0"]
                  [com.nedap.staffing-solutions/utils.modular "2.2.0"]
                  [com.stuartsierra/component "0.4.0"]
                  [garden "1.3.5"]
                  [org.apache.commons/commons-compress "1.18"]
                  [org.clojure/clojure "1.10.1"]
-                 [org.webjars/webjars-locator "0.27"
-                  :exclusions [org.apache.commons/commons-compress]]
+                 [org.webjars/webjars-locator "0.27"]
                  ;; Stefon needs it. We ensure a recent version is used, as the default (older) has an issue:
                  [ring/ring-core "1.5.0"]]
 
-  :managed-dependencies [[org.clojure/tools.cli "1.0.194"]]
+  :managed-dependencies [[clj-time "0.11.0"]
+                         [com.fasterxml.jackson.core/jackson-core "2.10.2"]
+                         [commons-codec "1.6"]
+                         [joda-time "2.8.2"]
+                         [org.clojure/tools.cli "1.0.194"]]
 
   :description "Clojure Component bundling Stefon, Garden and WebJars functionality."
 


### PR DESCRIPTION
## Brief

Drops the dependency on nedap/stefon.

## QA plan

- [x] https://clojars.org/com.nedap.staffing-solutions/components.assets/versions/3.0.2-alpha3

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
